### PR TITLE
task7: add authorizer and authorization

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/authorization-service/handler.js
+++ b/authorization-service/handler.js
@@ -1,0 +1,44 @@
+console.log('process.env.authConfig', process.env.authConfig);
+const authConfig = process.env.authConfig ? JSON.parse(process.env.authConfig) : {};
+const credentials = `${authConfig.user}:${authConfig.password}`;
+
+const generatePolicy = function(principalId, effect, resource) {
+  const authResponse = {};
+  authResponse.principalId = principalId;
+  if (effect && resource) {
+    const policyDocument = {};
+    policyDocument.Version = '2012-10-17'; // default version
+    policyDocument.Statement = [];
+    const statementOne = {};
+    statementOne.Action = '*'; // default action
+    statementOne.Effect = effect;
+    statementOne.Resource = resource;
+    policyDocument.Statement[0] = statementOne;
+    authResponse.policyDocument = policyDocument;
+  }
+
+  return authResponse;
+}
+
+const generateAllow = function(principalId, resource) {
+  return generatePolicy(principalId, 'Allow', resource);
+}
+
+const generateDeny = function(principalId, resource) {
+  return generatePolicy(principalId, 'Deny', resource);
+}
+
+module.exports.basicAuthorizer = (event, context, callback) => {
+  console.log(event)
+  const basicToken = String(event.authorizationToken).split(' ')[1];
+  if (!basicToken) {
+    return callback('Unauthorized');
+  }
+
+  const userPassword = Buffer.from(basicToken, 'base64').toString('ascii');
+  if (userPassword !== credentials) {
+    return callback(null, generateDeny('me', event.methodArn))
+  }
+
+  callback(null, generateAllow('me', event.methodArn));
+};

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "build": "serverless package",
+    "deploy": "serverless deploy",
+    "build:deploy": "npm run build && npm run deploy"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,21 @@
+service: authorization-service
+
+frameworkVersion: '2'
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  stage: dev
+  region: eu-west-1
+  lambdaHashingVersion: 20201221
+  environment:
+    authConfig: ${s3:nodejs-aws-be-variables/auth-config}
+
+functions:
+  basicAuthorizer:
+    handler: handler.basicAuthorizer
+
+resources:
+  Outputs:
+    BasicAuthorizerArn:
+      Value: !GetAtt BasicAuthorizerLambdaFunction.Arn

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -59,6 +59,8 @@ functions:
             parameters:
               querystrings:
                 name: true
+          authorizer:
+            arn: ${cf:authorization-service-dev.BasicAuthorizerArn}
 
   importFileParser:
     handler: src/handlers/import-file-parser.importFileParser
@@ -103,6 +105,15 @@ resources:
                 - 'x-amz-request-id'
                 - 'x-amz-id-2'
               MaxAge: 3000
+    GatewayResponse:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
     CatalogItemsQueue:
       Type: AWS::SQS::Queue
       Properties:

--- a/product-service/serverless.yml
+++ b/product-service/serverless.yml
@@ -24,6 +24,8 @@ functions:
           path: /products
           method: get
           cors: true
+          authorizer:
+            arn: arn:aws:cognito-idp:eu-west-1:583941112965:userpool/eu-west-1_pRzicT5x8
 
   getProductsById:
     handler: src/handlers/get-products.getProductsById
@@ -40,3 +42,15 @@ functions:
           path: /products
           method: post
           cors: true
+
+resources:
+  Resources:
+    GatewayResponse:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'


### PR DESCRIPTION
[Login form](https://87541237743.auth.eu-west-1.amazoncognito.com/login?client_id=6ppstn1tm871djmcl2s5qnvaqj&response_type=token&scope=aws.cognito.signin.user.admin+email+openid+phone+profile&redirect_uri=https://d2vdbjor2dbwpy.cloudfront.net/)
[Import products FE](https://d2vdbjor2dbwpy.cloudfront.net/admin/products)
[FE MR](https://github.com/roman-shuvalov/nodejs-aws-fe/pull/6)

1 (done) - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 (done) - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 (done) - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

+1 (done) - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file
just practice, no evaluation (done)